### PR TITLE
Feature - Add support for multiple application instances

### DIFF
--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -1,4 +1,3 @@
-import { Context } from '../data';
 import { ApiService } from '../service';
 
 export class AdminApi extends ApiService {
@@ -6,7 +5,7 @@ export class AdminApi extends ApiService {
     additionalHeaders?: object,
   ): Record<string, string> {
     let basicHeaders = super.getBasicHeaders(additionalHeaders);
-    const authToken = Context.getAuthToken();
+    const authToken = this.context.getAuthToken();
     if (authToken) {
       basicHeaders = {
         ...basicHeaders,

--- a/src/auth/admin.auth.ts
+++ b/src/auth/admin.auth.ts
@@ -1,15 +1,15 @@
 import { ApiService } from '../service';
 import { AuthorizationException } from '../exception';
 import { GrantParamsType, GrantType } from '../grant';
-import { AuthToken } from '../data';
+import { AuthToken, ContextData } from '../data';
 
 export class AdminAuth extends ApiService {
   public static OAUTH_TOKEN_ENDPOINT = '/oauth/token';
 
   private grantType: GrantType;
 
-  constructor(grantType: GrantType) {
-    super();
+  constructor(grantType: GrantType, context?: ContextData) {
+    super(context);
     this.grantType = grantType;
   }
 

--- a/src/data/repository.data.ts
+++ b/src/data/repository.data.ts
@@ -41,9 +41,10 @@ export class Repository {
     changesetGenerator: ChangesetGenerator,
     entityFactory: EntityFactory,
     options: RepositoryOptions,
+    context: ContextData,
   ) {
     this.route = route;
-    this.httpClient = createHTTPClient();
+    this.httpClient = createHTTPClient(context);
     this.entityDefinition = entityDefinition;
     this.entityName = entityDefinition.entity;
     this.hydrator = hydrator;

--- a/src/factory/repository.factory.ts
+++ b/src/factory/repository.factory.ts
@@ -1,5 +1,5 @@
 import {
-  ChangesetGenerator,
+  ChangesetGenerator, Context, ContextData,
   EntityFactory,
   Repository,
   RepositoryOptions,
@@ -11,11 +11,11 @@ export class RepositoryFactory {
   public static create(
     entityName: string,
     route = '',
-    options: RepositoryOptions = {}
+    options: RepositoryOptions = {},
+    context?: ContextData,
   ): Repository {
-    if (!route) {
-      route = `/${entityName.replace(/_/g, '-')}`;
-    }
+    route ||= `/${entityName.replace(/_/g, '-')}`;
+    context ||= Context;
 
     return new Repository(
       route,
@@ -23,7 +23,8 @@ export class RepositoryFactory {
       new EntityHydrator(),
       new ChangesetGenerator(),
       new EntityFactory(),
-      options
+      options,
+      context
     );
   }
 }

--- a/src/helper/refresh-token.helper.ts
+++ b/src/helper/refresh-token.helper.ts
@@ -2,12 +2,15 @@
  * Refresh token helper which manages a cache of requests to retry them after the token got refreshed.
  * @class RefreshTokenHelper
  */
-import { AuthToken, Context } from '../data';
+import { AuthToken, Context, ContextData } from '../data';
 import { RefreshTokenGrant } from '../grant';
 import { AdminAuth } from '../auth';
 
 export class RefreshTokenHelper {
   private _whitelists = ['/oauth/token'];
+
+  constructor(private readonly context: ContextData) {
+  }
 
   /**
    * Fires the refresh token request and renews the bearer authentication
@@ -17,13 +20,13 @@ export class RefreshTokenHelper {
    */
   async fireRefreshTokenRequest(originError: any): Promise<AuthToken> {
     try {
-      let authToken = Context.getAuthToken();
+      let authToken = this.context.getAuthToken();
       if (authToken) {
         const grantType = new RefreshTokenGrant(authToken.refreshToken);
-        const adminClient = new AdminAuth(grantType);
+        const adminClient = new AdminAuth(grantType, this.context);
 
         authToken = await adminClient.fetchAccessToken();
-        Context.setAuthToken(authToken);
+        this.context.setAuthToken(authToken);
 
         return authToken;
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Everything you want to publish
-import { Application } from './application';
+import { Application, ApplicationInstance } from './application';
 import {
   AdminApi,
   InfoApi,
@@ -26,6 +26,7 @@ import {
 
 export {
   Application,
+  ApplicationInstance,
   Context,
   AuthToken,
   Criteria,

--- a/src/service/api.service.ts
+++ b/src/service/api.service.ts
@@ -1,13 +1,21 @@
 import { AxiosInstance, AxiosRequestConfig } from 'axios';
 import createHTTPClient from '../service/http.service';
+import { Context, ContextData } from '../data';
 
 export abstract class ApiService {
+  protected readonly context: ContextData;
   protected httpClient: AxiosInstance;
   public contentType: string;
 
-  constructor(contentType = 'application/vnd.api+json') {
-    this.httpClient = createHTTPClient();
-    this.contentType = contentType;
+  constructor(context?: ContextData | string, contentType?: string) {
+    if (typeof context === 'string') {
+      contentType = context;
+      context = Context;
+    }
+
+    this.context = context ?? Context;
+    this.httpClient = createHTTPClient(this.context);
+    this.contentType = contentType ?? 'application/vnd.api+json';
   }
 
   protected serializeUrl(

--- a/src/service/http.service.ts
+++ b/src/service/http.service.ts
@@ -1,5 +1,5 @@
 import Axios, { AxiosError, AxiosInstance } from 'axios';
-import { AuthToken, Context } from '../data';
+import { AuthToken, ContextData } from '../data';
 import { types } from './util.service';
 import { Exception } from '../exception';
 import { RefreshTokenHelper } from '../helper/refresh-token.helper';
@@ -7,8 +7,8 @@ import { RefreshTokenHelper } from '../helper/refresh-token.helper';
 /**
  * Initializes the HTTP client with the provided context.
  */
-export default function createHTTPClient(): AxiosInstance {
-  return createClient();
+export default function createHTTPClient(context: ContextData): AxiosInstance {
+  return createClient(context);
 }
 
 /**
@@ -16,8 +16,8 @@ export default function createHTTPClient(): AxiosInstance {
  *
  * @returns {AxiosInstance}
  */
-const createClient = (): AxiosInstance => {
-  const apiEndPoint = Context.getApiEndPoint();
+const createClient = (context: ContextData): AxiosInstance => {
+  const apiEndPoint = context.getApiEndPoint();
   if (types.isEmpty(apiEndPoint)) {
     throw new Exception('Please provide shop-url to context');
   }
@@ -30,8 +30,8 @@ const createClient = (): AxiosInstance => {
     cancelToken: source.token,
   });
 
-  if (Context.isAutoCalRefresh()) {
-    refreshTokenInterceptor(client);
+  if (context.isAutoCalRefresh()) {
+    refreshTokenInterceptor(client, context);
   }
 
   return client;
@@ -41,10 +41,11 @@ const createClient = (): AxiosInstance => {
  * Sets up an interceptor to refresh the token, cache the requests and retry them after the token got refreshed.
  *
  * @param {AxiosInstance} client
+ * @param context
  * @returns {AxiosInstance}
  */
-function refreshTokenInterceptor(client: AxiosInstance): AxiosInstance {
-  const tokenHandler = new RefreshTokenHelper();
+function refreshTokenInterceptor(client: AxiosInstance, context: ContextData): AxiosInstance {
+  const tokenHandler = new RefreshTokenHelper(context);
 
   client.interceptors.response.use(
     (response) => response,


### PR DESCRIPTION
### Initial situation

At the moment, due to the static implementation, only one Shopware connection can be addressed via the 'Application' class.

### Goal

It should be possible to handle and sustain multiple connections to various Shopware installations.

### Implementation

I have tried to ensure full backward compatibility.
Please have a look at the concept and feel free to give feedback.

### Test

```ts
import { Application, ApplicationInstance, ClientCredentialsGrant, GRANT_SCOPE, InfoApi } from '@shapeandshift/shopware-node-sdk';

(async () => {
  Application.init({ shopUrl: 'http://localhost' });
  const shopwareApplication1 = new ApplicationInstance({ shopUrl: 'http://localhost' });
  const shopwareApplication2 = new ApplicationInstance({ shopUrl: 'http://localhost' });

  await Application.authenticate(new ClientCredentialsGrant(/* ... */);
  await shopwareApplication1.authenticate(new ClientCredentialsGrant(/* ... */);
  await shopwareApplication2.authenticate(new ClientCredentialsGrant(/* ... */);

  const staticInfoApi = new InfoApi();
  const app1InfoApi = new InfoApi(shopwareApplication1.getContext());
  const app2InfoApi = new InfoApi(shopwareApplication2.getContext());

  console.log({
    endpointStatic: {
      version: await staticInfoApi.getShopwareVersion(),
      token: Application.getContext()?.getAuthToken()?.accessToken,
    },
    endpointApp1: {
      version: await app1InfoApi.getShopwareVersion(),
      token: shopwareApplication1.getContext().getAuthToken()?.accessToken,
    },
    endpointApp2: {
      version: await app2InfoApi.getShopwareVersion(),
      token: shopwareApplication2.getContext().getAuthToken()?.accessToken,
    },
  });
})();
```
